### PR TITLE
Support 5120 files logged without 5120 template

### DIFF
--- a/src/org/nyet/ecuxplot/ECUxDataset.java
+++ b/src/org/nyet/ecuxplot/ECUxDataset.java
@@ -67,6 +67,24 @@ public class ECUxDataset extends Dataset {
 		}
 	    }
 	}
+
+    // check for 5120 logged without a 5120 template and double columns with unit of mBar if so
+    final Column baroPressure = get("BaroPressure");
+    if (baroPressure != null) {
+        final double measuredBaroPressure = baroPressure.data.get(0);
+        if (measuredBaroPressure < 600) {
+            //double time! ;)
+            for (Column column: getColumns()) {
+                String unit = column.getUnits();
+                if (unit != null && unit.toLowerCase().equals("mbar")) {
+					for (int i = 1; i < column.data.size(); i++) {
+						column.data.set(i, column.data.get(i) * 2);
+					}
+                }
+            }
+        }
+    }
+
 	// get RPM AFTER getting TIME, so we have an accurate samples per sec
 	this.rpm = get("RPM");
 	buildRanges(); // regenerate ranges, splines

--- a/src/org/nyet/ecuxplot/ECUxDataset.java
+++ b/src/org/nyet/ecuxplot/ECUxDataset.java
@@ -70,18 +70,12 @@ public class ECUxDataset extends Dataset {
 
     // check for 5120 logged without a 5120 template and double columns with unit of mBar if so
     final Column baroPressure = get("BaroPressure");
-    if (baroPressure != null) {
-		if (baroPressure.data.size() > 0) {
-			final double measuredBaroPressure = baroPressure.data.get(0);
-			if (measuredBaroPressure < 600) {
-				//double time! ;)
-				for (Column column : getColumns()) {
-					String unit = column.getUnits();
-					if (unit != null && unit.toLowerCase().equals("mbar")) {
-						for (int i = 1; i < column.data.size(); i++) {
-							column.data.set(i, column.data.get(i) * 2);
-						}
-					}
+    if (baroPressure != null && baroPressure.data.size() > 0 && baroPressure.data.get(0) < 600) {
+		//double time! ;)
+		for (Column column : getColumns()) {
+			if (column.getUnits() != null && column.getUnits().toLowerCase().equals("mbar")) {
+				for (int i = 1; i < column.data.size(); i++) {
+					column.data.set(i, column.data.get(i) * 2);
 				}
 			}
 		}

--- a/src/org/nyet/ecuxplot/ECUxDataset.java
+++ b/src/org/nyet/ecuxplot/ECUxDataset.java
@@ -71,18 +71,20 @@ public class ECUxDataset extends Dataset {
     // check for 5120 logged without a 5120 template and double columns with unit of mBar if so
     final Column baroPressure = get("BaroPressure");
     if (baroPressure != null) {
-        final double measuredBaroPressure = baroPressure.data.get(0);
-        if (measuredBaroPressure < 600) {
-            //double time! ;)
-            for (Column column: getColumns()) {
-                String unit = column.getUnits();
-                if (unit != null && unit.toLowerCase().equals("mbar")) {
-					for (int i = 1; i < column.data.size(); i++) {
-						column.data.set(i, column.data.get(i) * 2);
+		if (baroPressure.data.size() > 0) {
+			final double measuredBaroPressure = baroPressure.data.get(0);
+			if (measuredBaroPressure < 600) {
+				//double time! ;)
+				for (Column column : getColumns()) {
+					String unit = column.getUnits();
+					if (unit != null && unit.toLowerCase().equals("mbar")) {
+						for (int i = 1; i < column.data.size(); i++) {
+							column.data.set(i, column.data.get(i) * 2);
+						}
 					}
-                }
-            }
-        }
+				}
+			}
+		}
     }
 
 	// get RPM AFTER getting TIME, so we have an accurate samples per sec

--- a/src/org/nyet/ecuxplot/ECUxDataset.java
+++ b/src/org/nyet/ecuxplot/ECUxDataset.java
@@ -71,14 +71,14 @@ public class ECUxDataset extends Dataset {
     // check for 5120 logged without a 5120 template and double columns with unit of mBar if so
     final Column baroPressure = get("BaroPressure");
     if (baroPressure != null && baroPressure.data.size() > 0 && baroPressure.data.get(0) < 600) {
-		//double time! ;)
-		for (Column column : getColumns()) {
-			if (column.getUnits() != null && column.getUnits().toLowerCase().equals("mbar")) {
-				for (int i = 1; i < column.data.size(); i++) {
-					column.data.set(i, column.data.get(i) * 2);
-				}
-			}
-		}
+        //double time! ;)
+        for (Column column : getColumns()) {
+            if (column.getUnits() != null && column.getUnits().toLowerCase().equals("mbar")) {
+                for (int i = 1; i < column.data.size(); i++) {
+                    column.data.set(i, column.data.get(i) * 2);
+                }
+            }
+        }
     }
 
 	// get RPM AFTER getting TIME, so we have an accurate samples per sec

--- a/src/org/nyet/util/DoubleArray.java
+++ b/src/org/nyet/util/DoubleArray.java
@@ -85,6 +85,10 @@ public class DoubleArray
 	return i<this.sp?this.array[i]:0;
     }
 
+	public void set(int i, double value) {
+		this.array[i] = value;
+	}
+
     public double[] _func(TransferFunction f, double d) {
 	final double[] out = new double[ this.sp ];
 	for(int i=0;i<this.sp;i++) {

--- a/src/org/nyet/util/DoubleArray.java
+++ b/src/org/nyet/util/DoubleArray.java
@@ -85,9 +85,9 @@ public class DoubleArray
 	return i<this.sp?this.array[i]:0;
     }
 
-	public void set(int i, double value) {
-		this.array[i] = value;
-	}
+    public void set(int i, double value) {
+        this.array[i] = value;
+    }
 
     public double[] _func(TransferFunction f, double d) {
 	final double[] out = new double[ this.sp ];


### PR DESCRIPTION
If BaroPressure < 600, assume this log is of a 5120 file without a 5120 specific me7log template.   If so, double all the data in columns with unit of mBar.