### PR TITLE
Optimize Apply/OK/Restore Defaults to skip redundant work

### DIFF
--- a/src/org/nyet/ecuxplot/ECUxPlotWindow.java
+++ b/src/org/nyet/ecuxplot/ECUxPlotWindow.java
@@ -28,6 +28,13 @@ public abstract class ECUxPlotWindow extends JFrame {
     protected final Logger logger;
 
     /**
+     * Dirty flag to track whether user has made changes since last apply.
+     * Used to avoid redundant rebuilds when Apply/OK/Restore Defaults is
+     * clicked multiple times without intervening user changes.
+     */
+    private boolean dirty = false;
+
+    /**
      * File datasets - shared by windows that display file-based data
      */
     protected TreeMap<String, ECUxDataset> fileDatasets;
@@ -83,6 +90,30 @@ public abstract class ECUxPlotWindow extends JFrame {
      */
     protected boolean isFilterDisabled() {
         return filter != null && !filter.enabled();
+    }
+
+    /**
+     * Mark this window as dirty (user has made changes).
+     * Call this from change listeners on UI controls.
+     */
+    protected void markDirty() {
+        this.dirty = true;
+    }
+
+    /**
+     * Clear the dirty flag (changes have been applied).
+     * Call this after Apply/OK/Restore Defaults successfully completes.
+     */
+    protected void clearDirty() {
+        this.dirty = false;
+    }
+
+    /**
+     * Check if the window has unapplied user changes.
+     * @return true if the user has made changes since the last apply
+     */
+    protected boolean isDirty() {
+        return this.dirty;
     }
 }
 

--- a/src/org/nyet/ecuxplot/ECUxPlotWindow.java
+++ b/src/org/nyet/ecuxplot/ECUxPlotWindow.java
@@ -28,9 +28,14 @@ public abstract class ECUxPlotWindow extends JFrame {
     protected final Logger logger;
 
     /**
-     * Dirty flag to track whether user has made changes since last apply.
-     * Used to avoid redundant rebuilds when Apply/OK/Restore Defaults is
-     * clicked multiple times without intervening user changes.
+     * Tracks UI component state for change detection.
+     * Register components with stateTracker.track() at creation time.
+     */
+    protected final UIStateTracker stateTracker = new UIStateTracker();
+
+    /**
+     * Dirty flag for windows that cannot use component-based state tracking
+     * (e.g. tree-based selection in RangeSelectorWindow).
      */
     private boolean dirty = false;
 

--- a/src/org/nyet/ecuxplot/FATSChartFrame.java
+++ b/src/org/nyet/ecuxplot/FATSChartFrame.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 import javax.swing.*;
 
@@ -31,6 +32,10 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
     private JLabel rpmPerMphLabel;
     private JLabel unitLabel;
     private JPanel conversionGroup;
+
+    // State snapshot for avoiding redundant applies (Issue #121)
+    private Object[] lastAppliedState;
+    private boolean suppressComboAction = false;
 
     public static FATSChartFrame createFATSChartFrame(FATSDataset dataset, ECUxPlot plotFrame) {
         final FATS fats = plotFrame.fats; // Use the FATS instance from ECUxPlot
@@ -82,6 +87,7 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
         // Add action listener to combo box
         this.speedUnitCombo.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
+                if (suppressComboAction) return;
                 FATSChartFrame.this.fats.speedUnit(getSelectedSpeedUnit());
                 updateLabelsAndValues(FATSChartFrame.this.startLabel, FATSChartFrame.this.endLabel, FATSChartFrame.this.start, FATSChartFrame.this.end);
                 updateRpmFieldsVisibility();
@@ -89,6 +95,8 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
                 FATSChartFrame.this.dataset.refreshFromFATS();
                 FATSChartFrame.this.getChartPanel().getChart().setTitle(FATSChartFrame.this.dataset.getTitle());
                 notifyRangeSelector();
+                // Combo box auto-applies, update snapshot so Apply is a no-op
+                lastAppliedState = captureState();
             }
         });
 
@@ -179,6 +187,22 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
         // Set initial combo box selection and visibility
         updateComboBoxSelection();
         updateRpmFieldsVisibility();
+
+        // Snapshot the initial state so the first Apply is a no-op if nothing changed
+        lastAppliedState = captureState();
+    }
+
+    /**
+     * Capture the current UI state for comparison.
+     * Used to detect whether settings have changed since the last apply.
+     */
+    private Object[] captureState() {
+        return new Object[] {
+            this.speedUnitCombo.getSelectedItem(),
+            this.start.getText(),
+            this.end.getText(),
+            this.rpmPerMphField != null ? this.rpmPerMphField.getText() : null
+        };
     }
 
     public FATSDataset getDataset() {
@@ -258,6 +282,8 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent event) {
         if(event.getActionCommand().equals("Apply")) {
+            if (Arrays.equals(captureState(), lastAppliedState)) return;
+
             FATS.SpeedUnit speedUnit = getSelectedSpeedUnit();
             this.fats.speedUnit(speedUnit);
 
@@ -288,6 +314,8 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
                 this.plotFrame.env.c.rpm_per_mph(newRpmPerMph);
             }
 
+            lastAppliedState = captureState();
+
             // If rpm_per_mph changed, invalidate column caches and rebuild charts
             // This ensures Calc Velocity, WHP, HP, etc. are recalculated with new constant
             if (rpmPerMphChanged) {
@@ -298,6 +326,16 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
                 notifyRangeSelector();
             }
         } else if(event.getActionCommand().equals("Defaults")) {
+            // Update text fields and combo to show defaults first
+            this.start.setText("4200");
+            this.end.setText("6500");
+            suppressComboAction = true;
+            this.speedUnitCombo.setSelectedItem("RPM");
+            suppressComboAction = false;
+
+            // Skip rebuild if the defaults match what was last applied
+            if (Arrays.equals(captureState(), lastAppliedState)) return;
+
             // Restore all defaults: RPM, mph, and kph
             this.fats.speedUnit(FATS.SpeedUnit.RPM);
             this.fats.start(4200);
@@ -307,13 +345,12 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
             this.fats.startKph(100.0);
             this.fats.endKph(150.0);
             this.dataset.refreshFromFATS();
-            // Update text fields to show defaults
-            this.start.setText("4200");
-            this.end.setText("6500");
-            // Update radio buttons to reflect defaults
+            // Update combo and visibility to reflect defaults
             updateComboBoxSelection();
             updateRpmFieldsVisibility();
             notifyRangeSelector();
+
+            lastAppliedState = captureState();
         }
         this.getChartPanel().getChart().setTitle(this.dataset.getTitle());
     }

--- a/src/org/nyet/ecuxplot/FATSChartFrame.java
+++ b/src/org/nyet/ecuxplot/FATSChartFrame.java
@@ -5,7 +5,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 
 import javax.swing.*;
 
@@ -33,8 +32,8 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
     private JLabel unitLabel;
     private JPanel conversionGroup;
 
-    // State snapshot for avoiding redundant applies (Issue #121)
-    private Object[] lastAppliedState;
+    // State tracking for avoiding redundant applies (Issue #121)
+    private final UIStateTracker stateTracker = new UIStateTracker();
     private boolean suppressComboAction = false;
 
     public static FATSChartFrame createFATSChartFrame(FATSDataset dataset, ECUxPlot plotFrame) {
@@ -96,7 +95,7 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
                 FATSChartFrame.this.getChartPanel().getChart().setTitle(FATSChartFrame.this.dataset.getTitle());
                 notifyRangeSelector();
                 // Combo box auto-applies, update snapshot so Apply is a no-op
-                lastAppliedState = captureState();
+                stateTracker.snapshot();
             }
         });
 
@@ -188,21 +187,14 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
         updateComboBoxSelection();
         updateRpmFieldsVisibility();
 
-        // Snapshot the initial state so the first Apply is a no-op if nothing changed
-        lastAppliedState = captureState();
-    }
+        // Register components for state tracking (Issue #121)
+        stateTracker.track(this.speedUnitCombo);
+        stateTracker.track(this.start);
+        stateTracker.track(this.end);
+        stateTracker.track(this.rpmPerMphField);
 
-    /**
-     * Capture the current UI state for comparison.
-     * Used to detect whether settings have changed since the last apply.
-     */
-    private Object[] captureState() {
-        return new Object[] {
-            this.speedUnitCombo.getSelectedItem(),
-            this.start.getText(),
-            this.end.getText(),
-            this.rpmPerMphField != null ? this.rpmPerMphField.getText() : null
-        };
+        // Snapshot the initial state so the first Apply is a no-op if nothing changed
+        stateTracker.snapshot();
     }
 
     public FATSDataset getDataset() {
@@ -282,7 +274,7 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent event) {
         if(event.getActionCommand().equals("Apply")) {
-            if (Arrays.equals(captureState(), lastAppliedState)) return;
+            if (!stateTracker.hasChanged()) return;
 
             FATS.SpeedUnit speedUnit = getSelectedSpeedUnit();
             this.fats.speedUnit(speedUnit);
@@ -314,7 +306,7 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
                 this.plotFrame.env.c.rpm_per_mph(newRpmPerMph);
             }
 
-            lastAppliedState = captureState();
+            stateTracker.snapshot();
 
             // If rpm_per_mph changed, invalidate column caches and rebuild charts
             // This ensures Calc Velocity, WHP, HP, etc. are recalculated with new constant
@@ -334,7 +326,7 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
             suppressComboAction = false;
 
             // Skip rebuild if the defaults match what was last applied
-            if (Arrays.equals(captureState(), lastAppliedState)) return;
+            if (!stateTracker.hasChanged()) return;
 
             // Restore all defaults: RPM, mph, and kph
             this.fats.speedUnit(FATS.SpeedUnit.RPM);
@@ -350,7 +342,7 @@ public class FATSChartFrame extends ChartFrame implements ActionListener {
             updateRpmFieldsVisibility();
             notifyRangeSelector();
 
-            lastAppliedState = captureState();
+            stateTracker.snapshot();
         }
         this.getChartPanel().getChart().setTitle(this.dataset.getTitle());
     }

--- a/src/org/nyet/ecuxplot/FATSEditor.java
+++ b/src/org/nyet/ecuxplot/FATSEditor.java
@@ -139,6 +139,17 @@ public class FATSEditor extends PreferencesEditor {
     }
 
     @Override
+    protected Object[] captureState() {
+        // Capture custom fields directly (addPairs fields are replaced)
+        return new Object[] {
+            this.start.getText(),
+            this.end.getText(),
+            this.rpmPerMph.getText(),
+            this.speedUnitCombo.getSelectedItem()
+        };
+    }
+
+    @Override
     public void updateDialog() {
         FATS.SpeedUnit speedUnit = this.s.speedUnit();
         switch (speedUnit) {

--- a/src/org/nyet/ecuxplot/FATSEditor.java
+++ b/src/org/nyet/ecuxplot/FATSEditor.java
@@ -136,17 +136,13 @@ public class FATSEditor extends PreferencesEditor {
         // Initialize labels and visibility
         updateLabels();
         updateRpmFieldsVisibility();
-    }
 
-    @Override
-    protected Object[] captureState() {
-        // Capture custom fields directly (addPairs fields are replaced)
-        return new Object[] {
-            this.start.getText(),
-            this.end.getText(),
-            this.rpmPerMph.getText(),
-            this.speedUnitCombo.getSelectedItem()
-        };
+        // Replace parent's addPairs tracking with our custom fields
+        stateTracker.clear();
+        stateTracker.track(this.start);
+        stateTracker.track(this.end);
+        stateTracker.track(this.rpmPerMph);
+        stateTracker.track(this.speedUnitCombo);
     }
 
     @Override

--- a/src/org/nyet/ecuxplot/FilterWindow.java
+++ b/src/org/nyet/ecuxplot/FilterWindow.java
@@ -6,6 +6,7 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.TreeMap;
 
 import javax.swing.*;
@@ -37,6 +38,9 @@ public class FilterWindow extends ECUxPlotWindow {
     private JTextField minAcceleration;
     private JTextField accelMAW;
     private JTextField minPoints;
+
+    // State snapshot for avoiding redundant applies (Issue #121)
+    private Object[] lastAppliedState;
 
     // Data visualization components
     private ECUxDataset dataset;
@@ -167,6 +171,9 @@ public class FilterWindow extends ECUxPlotWindow {
         initializeComponents();
         setupLayout();
         updateDialog();
+
+        // Snapshot the initial state so the first Apply is a no-op if nothing changed
+        lastAppliedState = captureState();
 
         // Add window listener to save size when window is closed
         addWindowListener(new java.awt.event.WindowAdapter() {
@@ -1067,9 +1074,35 @@ public class FilterWindow extends ECUxPlotWindow {
      * Apply filter changes and rebuild the plot
      * @throws Exception if any error occurs during the process
      */
+    /**
+     * Capture the current UI state for comparison.
+     * Used to detect whether settings have changed since the last apply.
+     */
+    private Object[] captureState() {
+        return new Object[] {
+            gear.getValue(),
+            minRPM.getText(),
+            maxRPM.getText(),
+            minRPMRange.getText(),
+            monotonicRPMfuzz.getText(),
+            minPedal.getText(),
+            minThrottle.getText(),
+            minAcceleration.getText(),
+            accelMAW.getText(),
+            minPoints.getText()
+        };
+    }
+
     private void applyFilterChanges() throws Exception {
+        if (Arrays.equals(captureState(), lastAppliedState)) {
+            clearTopWindow();
+            return;
+        }
+
         // Actually read the values from the text fields and apply them
         processFilterChanges();
+
+        lastAppliedState = captureState();
 
         // Window is already set as top by the button action listener
 
@@ -1112,8 +1145,16 @@ public class FilterWindow extends ECUxPlotWindow {
         // Update the dialog to show default values
         updateDialog();
 
+        // Skip rebuild if the defaults match what was last applied
+        if (Arrays.equals(captureState(), lastAppliedState)) {
+            clearTopWindow();
+            return;
+        }
+
         // Process the filter changes (same as Apply button)
         processFilterChanges();
+
+        lastAppliedState = captureState();
 
         if (this.eplot != null) {
             this.eplot.rebuild(() -> {

--- a/src/org/nyet/ecuxplot/FilterWindow.java
+++ b/src/org/nyet/ecuxplot/FilterWindow.java
@@ -6,7 +6,6 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.TreeMap;
 
 import javax.swing.*;
@@ -38,9 +37,6 @@ public class FilterWindow extends ECUxPlotWindow {
     private JTextField minAcceleration;
     private JTextField accelMAW;
     private JTextField minPoints;
-
-    // State snapshot for avoiding redundant applies (Issue #121)
-    private Object[] lastAppliedState;
 
     // Data visualization components
     private ECUxDataset dataset;
@@ -173,7 +169,7 @@ public class FilterWindow extends ECUxPlotWindow {
         updateDialog();
 
         // Snapshot the initial state so the first Apply is a no-op if nothing changed
-        lastAppliedState = captureState();
+        stateTracker.snapshot();
 
         // Add window listener to save size when window is closed
         addWindowListener(new java.awt.event.WindowAdapter() {
@@ -211,6 +207,18 @@ public class FilterWindow extends ECUxPlotWindow {
         minAcceleration = new JTextField(10);
         minPoints = new JTextField(10);
         accelMAW = new JTextField(10);
+
+        // Register components for state tracking (Issue #121)
+        stateTracker.track(gear);
+        stateTracker.track(minRPM);
+        stateTracker.track(maxRPM);
+        stateTracker.track(minRPMRange);
+        stateTracker.track(monotonicRPMfuzz);
+        stateTracker.track(minPedal);
+        stateTracker.track(minThrottle);
+        stateTracker.track(minAcceleration);
+        stateTracker.track(accelMAW);
+        stateTracker.track(minPoints);
 
         // Add change listeners to automatically refresh visualization
         addChangeListeners();
@@ -1074,27 +1082,8 @@ public class FilterWindow extends ECUxPlotWindow {
      * Apply filter changes and rebuild the plot
      * @throws Exception if any error occurs during the process
      */
-    /**
-     * Capture the current UI state for comparison.
-     * Used to detect whether settings have changed since the last apply.
-     */
-    private Object[] captureState() {
-        return new Object[] {
-            gear.getValue(),
-            minRPM.getText(),
-            maxRPM.getText(),
-            minRPMRange.getText(),
-            monotonicRPMfuzz.getText(),
-            minPedal.getText(),
-            minThrottle.getText(),
-            minAcceleration.getText(),
-            accelMAW.getText(),
-            minPoints.getText()
-        };
-    }
-
     private void applyFilterChanges() throws Exception {
-        if (Arrays.equals(captureState(), lastAppliedState)) {
+        if (!stateTracker.hasChanged()) {
             clearTopWindow();
             return;
         }
@@ -1102,7 +1091,7 @@ public class FilterWindow extends ECUxPlotWindow {
         // Actually read the values from the text fields and apply them
         processFilterChanges();
 
-        lastAppliedState = captureState();
+        stateTracker.snapshot();
 
         // Window is already set as top by the button action listener
 
@@ -1146,7 +1135,7 @@ public class FilterWindow extends ECUxPlotWindow {
         updateDialog();
 
         // Skip rebuild if the defaults match what was last applied
-        if (Arrays.equals(captureState(), lastAppliedState)) {
+        if (!stateTracker.hasChanged()) {
             clearTopWindow();
             return;
         }
@@ -1154,7 +1143,7 @@ public class FilterWindow extends ECUxPlotWindow {
         // Process the filter changes (same as Apply button)
         processFilterChanges();
 
-        lastAppliedState = captureState();
+        stateTracker.snapshot();
 
         if (this.eplot != null) {
             this.eplot.rebuild(() -> {

--- a/src/org/nyet/ecuxplot/PIDEditor.java
+++ b/src/org/nyet/ecuxplot/PIDEditor.java
@@ -114,6 +114,17 @@ public class PIDEditor extends PreferencesEditor {
         gbc.gridx = 1; gbc.gridy = 5;
         gbc.anchor = GridBagConstraints.WEST;
         pp.add(pd, gbc);
+
+        // Register fields for state tracking (Issue #121)
+        trackField(this.time_constant);
+        trackField(this.P_deadband);
+        trackField(this.I_limit);
+        trackField(this.P);
+        trackField(this.I);
+        trackField(this.D0);
+        trackField(this.D1);
+        trackField(this.D2);
+        trackField(this.D3);
     }
 
     @Override

--- a/src/org/nyet/ecuxplot/PIDEditor.java
+++ b/src/org/nyet/ecuxplot/PIDEditor.java
@@ -116,15 +116,15 @@ public class PIDEditor extends PreferencesEditor {
         pp.add(pd, gbc);
 
         // Register fields for state tracking (Issue #121)
-        trackField(this.time_constant);
-        trackField(this.P_deadband);
-        trackField(this.I_limit);
-        trackField(this.P);
-        trackField(this.I);
-        trackField(this.D0);
-        trackField(this.D1);
-        trackField(this.D2);
-        trackField(this.D3);
+        stateTracker.track(this.time_constant);
+        stateTracker.track(this.P_deadband);
+        stateTracker.track(this.I_limit);
+        stateTracker.track(this.P);
+        stateTracker.track(this.I);
+        stateTracker.track(this.D0);
+        stateTracker.track(this.D1);
+        stateTracker.track(this.D2);
+        stateTracker.track(this.D3);
     }
 
     @Override

--- a/src/org/nyet/ecuxplot/PreferencesEditor.java
+++ b/src/org/nyet/ecuxplot/PreferencesEditor.java
@@ -2,6 +2,8 @@ package org.nyet.ecuxplot;
 
 import java.lang.reflect.*;
 import java.util.prefs.Preferences;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.awt.*;
 import java.awt.event.*;
 
@@ -20,6 +22,39 @@ public class PreferencesEditor extends JPanel {
     private final JPanel prefsPanel;
 
     private final Preferences prefs;
+
+    // State snapshot for avoiding redundant applies (Issue #121)
+    private final ArrayList<JTextField> trackedFields = new ArrayList<>();
+    private Object[] lastAppliedState;
+
+    /**
+     * Capture the current UI state for comparison.
+     * Used to detect whether settings have changed since the last apply.
+     * Subclasses that create custom fields (not via addPairs) should override this.
+     */
+    protected Object[] captureState() {
+        Object[] state = new Object[trackedFields.size()];
+        for (int i = 0; i < trackedFields.size(); i++) {
+            state[i] = trackedFields.get(i).getText();
+        }
+        return state;
+    }
+
+    /**
+     * Register a text field for state tracking.
+     * Use this for fields created outside addPairs() (e.g., in subclass constructors).
+     */
+    protected void trackField(JTextField field) {
+        trackedFields.add(field);
+    }
+
+    /**
+     * Update the state snapshot to reflect the currently applied values.
+     * Called after successful apply or restore defaults.
+     */
+    protected void snapshotState() {
+        lastAppliedState = captureState();
+    }
 
     protected void Process(ActionEvent event) {
         if(this.eplot!=null) this.eplot.rebuild();
@@ -62,8 +97,13 @@ public class PreferencesEditor extends JPanel {
                 }
             }
 
-            if(this.eplot!=null) this.eplot.rebuild();
             updateDialog();
+
+            // Skip rebuild if the defaults match what was last applied
+            if (Arrays.equals(captureState(), lastAppliedState)) return;
+
+            if(this.eplot!=null) this.eplot.rebuild();
+            snapshotState();
         }
     }
 
@@ -111,6 +151,11 @@ public class PreferencesEditor extends JPanel {
                     tf = new JLabel("");
                 fld.set(this, tf);
 
+                // Track text fields for state snapshot (Issue #121)
+                if (tf instanceof JTextField) {
+                    trackedFields.add((JTextField) tf);
+                }
+
                 gbc.gridx = 1;
                 gbc.gridy = i;
                 gbc.anchor = GridBagConstraints.WEST;
@@ -148,7 +193,10 @@ public class PreferencesEditor extends JPanel {
             @Override
             public void actionPerformed(ActionEvent event) {
                 PreferencesEditor.this.ok = true;
-                Process(event);
+                if (!Arrays.equals(captureState(), lastAppliedState)) {
+                    Process(event);
+                    snapshotState();
+                }
                 PreferencesEditor.this.dialog.setVisible(false);
             }
         });
@@ -159,8 +207,10 @@ public class PreferencesEditor extends JPanel {
         jbtn.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent event) {
+                if (Arrays.equals(captureState(), lastAppliedState)) return;
                 PreferencesEditor.this.ok = true;
                 Process(event);
+                snapshotState();
             }
         });
         panel.add(jbtn);
@@ -209,6 +259,8 @@ public class PreferencesEditor extends JPanel {
 
     public boolean showDialog(Component parent, String title) {
         updateDialog();
+        // Snapshot state after updateDialog so Apply is a no-op if nothing changed
+        snapshotState();
         this.ok = false;
         Frame owner;
 

--- a/src/org/nyet/ecuxplot/PreferencesEditor.java
+++ b/src/org/nyet/ecuxplot/PreferencesEditor.java
@@ -2,8 +2,6 @@ package org.nyet.ecuxplot;
 
 import java.lang.reflect.*;
 import java.util.prefs.Preferences;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.awt.*;
 import java.awt.event.*;
 
@@ -23,38 +21,11 @@ public class PreferencesEditor extends JPanel {
 
     private final Preferences prefs;
 
-    // State snapshot for avoiding redundant applies (Issue #121)
-    private final ArrayList<JTextField> trackedFields = new ArrayList<>();
-    private Object[] lastAppliedState;
-
     /**
-     * Capture the current UI state for comparison.
-     * Used to detect whether settings have changed since the last apply.
-     * Subclasses that create custom fields (not via addPairs) should override this.
+     * Tracks UI component state for change detection.
+     * Register components with stateTracker.track() at creation time.
      */
-    protected Object[] captureState() {
-        Object[] state = new Object[trackedFields.size()];
-        for (int i = 0; i < trackedFields.size(); i++) {
-            state[i] = trackedFields.get(i).getText();
-        }
-        return state;
-    }
-
-    /**
-     * Register a text field for state tracking.
-     * Use this for fields created outside addPairs() (e.g., in subclass constructors).
-     */
-    protected void trackField(JTextField field) {
-        trackedFields.add(field);
-    }
-
-    /**
-     * Update the state snapshot to reflect the currently applied values.
-     * Called after successful apply or restore defaults.
-     */
-    protected void snapshotState() {
-        lastAppliedState = captureState();
-    }
+    protected final UIStateTracker stateTracker = new UIStateTracker();
 
     protected void Process(ActionEvent event) {
         if(this.eplot!=null) this.eplot.rebuild();
@@ -100,10 +71,10 @@ public class PreferencesEditor extends JPanel {
             updateDialog();
 
             // Skip rebuild if the defaults match what was last applied
-            if (Arrays.equals(captureState(), lastAppliedState)) return;
+            if (!stateTracker.hasChanged()) return;
 
             if(this.eplot!=null) this.eplot.rebuild();
-            snapshotState();
+            stateTracker.snapshot();
         }
     }
 
@@ -153,7 +124,7 @@ public class PreferencesEditor extends JPanel {
 
                 // Track text fields for state snapshot (Issue #121)
                 if (tf instanceof JTextField) {
-                    trackedFields.add((JTextField) tf);
+                    stateTracker.track((JTextField) tf);
                 }
 
                 gbc.gridx = 1;
@@ -193,9 +164,9 @@ public class PreferencesEditor extends JPanel {
             @Override
             public void actionPerformed(ActionEvent event) {
                 PreferencesEditor.this.ok = true;
-                if (!Arrays.equals(captureState(), lastAppliedState)) {
+                if (stateTracker.hasChanged()) {
                     Process(event);
-                    snapshotState();
+                    stateTracker.snapshot();
                 }
                 PreferencesEditor.this.dialog.setVisible(false);
             }
@@ -207,10 +178,10 @@ public class PreferencesEditor extends JPanel {
         jbtn.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent event) {
-                if (Arrays.equals(captureState(), lastAppliedState)) return;
+                if (!stateTracker.hasChanged()) return;
                 PreferencesEditor.this.ok = true;
                 Process(event);
-                snapshotState();
+                stateTracker.snapshot();
             }
         });
         panel.add(jbtn);
@@ -260,7 +231,7 @@ public class PreferencesEditor extends JPanel {
     public boolean showDialog(Component parent, String title) {
         updateDialog();
         // Snapshot state after updateDialog so Apply is a no-op if nothing changed
-        snapshotState();
+        stateTracker.snapshot();
         this.ok = false;
         Frame owner;
 

--- a/src/org/nyet/ecuxplot/RangeSelectorWindow.java
+++ b/src/org/nyet/ecuxplot/RangeSelectorWindow.java
@@ -677,6 +677,7 @@ public class RangeSelectorWindow extends ECUxPlotWindow implements FileDropHost 
 
                         rangeTree.repaint();
                         updateStatus();
+                        markDirty();
                     }
                 }
             }
@@ -1716,6 +1717,7 @@ public class RangeSelectorWindow extends ECUxPlotWindow implements FileDropHost 
         }
         rangeTree.repaint();
         updateStatus();
+        markDirty();
     }
 
     private void selectNone() {
@@ -1730,9 +1732,12 @@ public class RangeSelectorWindow extends ECUxPlotWindow implements FileDropHost 
         }
         rangeTree.repaint();
         updateStatus();
+        markDirty();
     }
 
     private void applySelection() {
+        if (!isDirty()) return;
+
         DefaultMutableTreeNode root = (DefaultMutableTreeNode) treeModel.getRoot();
         Enumeration<?> enumeration = root.depthFirstEnumeration();
 
@@ -1830,6 +1835,8 @@ public class RangeSelectorWindow extends ECUxPlotWindow implements FileDropHost 
 
             updateStatus();
         }
+
+        clearDirty();
     }
 
 

--- a/src/org/nyet/ecuxplot/SmoothingWindow.java
+++ b/src/org/nyet/ecuxplot/SmoothingWindow.java
@@ -5,6 +5,7 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.TreeMap;
 import javax.swing.*;
 import javax.swing.table.*;
@@ -43,6 +44,9 @@ public class SmoothingWindow extends ECUxPlotWindow {
     private JTextField HPMAW;
     private JTextField ZeitMAW;
     private JButton okButton; // Store reference to OK button
+
+    // State snapshot for avoiding redundant applies (Issue #121)
+    private Object[] lastAppliedState;
 
     // Data
     private TreeMap<String, ECUxDataset> fileDatasets;
@@ -95,6 +99,9 @@ public class SmoothingWindow extends ECUxPlotWindow {
 
         initializeComponents();
         setupLayout();
+
+        // Snapshot the initial state so the first Apply is a no-op if nothing changed
+        lastAppliedState = captureState();
 
         // Add window listener to save size when window is closed
         addWindowListener(new java.awt.event.WindowAdapter() {
@@ -923,12 +930,33 @@ public class SmoothingWindow extends ECUxPlotWindow {
     }
 
     /**
+     * Capture the current UI state for comparison.
+     * Used to detect whether settings have changed since the last apply.
+     */
+    private Object[] captureState() {
+        return new Object[] {
+            smoothingStrategyCombo.getSelectedItem(),
+            leftPaddingCombo.getSelectedItem(),
+            rightPaddingCombo.getSelectedItem(),
+            HPMAW.getText(),
+            ZeitMAW.getText()
+        };
+    }
+
+    /**
      * Apply smoothing changes and rebuild the plot
      * @throws Exception if any error occurs during the process
      */
     private void applySmoothingChanges() throws Exception {
+        if (Arrays.equals(captureState(), lastAppliedState)) {
+            clearTopWindow();
+            return;
+        }
+
         // Process smoothing changes from UI controls
         processSmoothingChanges();
+
+        lastAppliedState = captureState();
 
         // Window is already set as top by the button action listener
 
@@ -991,19 +1019,25 @@ public class SmoothingWindow extends ECUxPlotWindow {
         final Strategy defaultStrategy = Strategy.MAW;
         final Smoothing.PaddingConfig defaultPadding = Smoothing.PaddingConfig.forStrategy(defaultStrategy);
 
-        // Restore HPMAW and ZeitMAW to defaults
-        if (filter != null) {
-            filter.HPMAW(1.5); // defaultHPMAW
-            filter.ZeitMAW(1.5); // defaultZeitMAW
-        }
-
         // Update UI controls to show default values
         smoothingStrategyCombo.setSelectedItem(defaultStrategy);
         leftPaddingCombo.setSelectedItem(defaultPadding.left);
         rightPaddingCombo.setSelectedItem(defaultPadding.right);
         if (filter != null) {
-            HPMAW.setText(String.valueOf(filter.HPMAW()));
-            ZeitMAW.setText(String.valueOf(filter.ZeitMAW()));
+            HPMAW.setText(String.valueOf(1.5));
+            ZeitMAW.setText(String.valueOf(1.5));
+        }
+
+        // Skip rebuild if the defaults match what was last applied
+        if (Arrays.equals(captureState(), lastAppliedState)) {
+            clearTopWindow();
+            return;
+        }
+
+        // Restore HPMAW and ZeitMAW to defaults
+        if (filter != null) {
+            filter.HPMAW(1.5); // defaultHPMAW
+            filter.ZeitMAW(1.5); // defaultZeitMAW
         }
 
         // Apply defaults to all datasets
@@ -1016,6 +1050,8 @@ public class SmoothingWindow extends ECUxPlotWindow {
 
         // Process the smoothing changes (same as Apply button)
         processSmoothingChanges();
+
+        lastAppliedState = captureState();
 
         if (this.eplot != null) {
             this.eplot.rebuild(() -> {

--- a/src/org/nyet/ecuxplot/SmoothingWindow.java
+++ b/src/org/nyet/ecuxplot/SmoothingWindow.java
@@ -5,7 +5,6 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.TreeMap;
 import javax.swing.*;
 import javax.swing.table.*;
@@ -44,9 +43,6 @@ public class SmoothingWindow extends ECUxPlotWindow {
     private JTextField HPMAW;
     private JTextField ZeitMAW;
     private JButton okButton; // Store reference to OK button
-
-    // State snapshot for avoiding redundant applies (Issue #121)
-    private Object[] lastAppliedState;
 
     // Data
     private TreeMap<String, ECUxDataset> fileDatasets;
@@ -101,7 +97,7 @@ public class SmoothingWindow extends ECUxPlotWindow {
         setupLayout();
 
         // Snapshot the initial state so the first Apply is a no-op if nothing changed
-        lastAppliedState = captureState();
+        stateTracker.snapshot();
 
         // Add window listener to save size when window is closed
         addWindowListener(new java.awt.event.WindowAdapter() {
@@ -288,6 +284,13 @@ public class SmoothingWindow extends ECUxPlotWindow {
         // ZeitMAW control
         ZeitMAW = new JTextField(10);
         ZeitMAW.setToolTipText("Zeitronix boost pressure smoothing window (seconds). Affects: Zeitronix Boost (PSI) - range-aware smoothing");
+
+        // Register components for state tracking (Issue #121)
+        stateTracker.track(smoothingStrategyCombo);
+        stateTracker.track(leftPaddingCombo);
+        stateTracker.track(rightPaddingCombo);
+        stateTracker.track(HPMAW);
+        stateTracker.track(ZeitMAW);
     }
 
     private void setupLayout() {
@@ -930,25 +933,11 @@ public class SmoothingWindow extends ECUxPlotWindow {
     }
 
     /**
-     * Capture the current UI state for comparison.
-     * Used to detect whether settings have changed since the last apply.
-     */
-    private Object[] captureState() {
-        return new Object[] {
-            smoothingStrategyCombo.getSelectedItem(),
-            leftPaddingCombo.getSelectedItem(),
-            rightPaddingCombo.getSelectedItem(),
-            HPMAW.getText(),
-            ZeitMAW.getText()
-        };
-    }
-
-    /**
      * Apply smoothing changes and rebuild the plot
      * @throws Exception if any error occurs during the process
      */
     private void applySmoothingChanges() throws Exception {
-        if (Arrays.equals(captureState(), lastAppliedState)) {
+        if (!stateTracker.hasChanged()) {
             clearTopWindow();
             return;
         }
@@ -956,7 +945,7 @@ public class SmoothingWindow extends ECUxPlotWindow {
         // Process smoothing changes from UI controls
         processSmoothingChanges();
 
-        lastAppliedState = captureState();
+        stateTracker.snapshot();
 
         // Window is already set as top by the button action listener
 
@@ -1029,7 +1018,7 @@ public class SmoothingWindow extends ECUxPlotWindow {
         }
 
         // Skip rebuild if the defaults match what was last applied
-        if (Arrays.equals(captureState(), lastAppliedState)) {
+        if (!stateTracker.hasChanged()) {
             clearTopWindow();
             return;
         }
@@ -1051,7 +1040,7 @@ public class SmoothingWindow extends ECUxPlotWindow {
         // Process the smoothing changes (same as Apply button)
         processSmoothingChanges();
 
-        lastAppliedState = captureState();
+        stateTracker.snapshot();
 
         if (this.eplot != null) {
             this.eplot.rebuild(() -> {

--- a/src/org/nyet/ecuxplot/UIStateTracker.java
+++ b/src/org/nyet/ecuxplot/UIStateTracker.java
@@ -1,0 +1,82 @@
+package org.nyet.ecuxplot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JRadioButton;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+
+/**
+ * Tracks UI component state for change detection.
+ * <p>
+ * Register components with {@link #track(JComponent)} at creation time,
+ * then use {@link #snapshot()} to save the baseline state and
+ * {@link #hasChanged()} to detect whether the user has made changes.
+ * <p>
+ * Supports JTextField, JComboBox, JSpinner, JCheckBox, and JRadioButton.
+ * Implements {@link Cloneable} so the tracker (and its snapshot) can be copied.
+ */
+public class UIStateTracker implements Cloneable {
+
+    private final List<JComponent> tracked = new ArrayList<>();
+    private List<Object> lastSnapshot;
+
+    /** Register a UI component for state tracking. */
+    public void track(JComponent component) {
+        tracked.add(component);
+    }
+
+    /** Remove all tracked components and clear the snapshot. */
+    public void clear() {
+        tracked.clear();
+        lastSnapshot = null;
+    }
+
+    /** Save the current state as the baseline for comparison. */
+    public void snapshot() {
+        lastSnapshot = captureValues();
+    }
+
+    /** Check if any tracked component has changed since the last snapshot. */
+    public boolean hasChanged() {
+        return lastSnapshot == null || !captureValues().equals(lastSnapshot);
+    }
+
+    private List<Object> captureValues() {
+        List<Object> values = new ArrayList<>(tracked.size());
+        for (JComponent c : tracked) {
+            values.add(extractValue(c));
+        }
+        return values;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static Object extractValue(JComponent c) {
+        if (c instanceof JTextField)    return ((JTextField) c).getText();
+        if (c instanceof JComboBox)     return ((JComboBox) c).getSelectedItem();
+        if (c instanceof JSpinner)      return ((JSpinner) c).getValue();
+        if (c instanceof JCheckBox)     return ((JCheckBox) c).isSelected();
+        if (c instanceof JRadioButton)  return ((JRadioButton) c).isSelected();
+        throw new IllegalArgumentException(
+            "Unsupported component type: " + c.getClass().getName());
+    }
+
+    @Override
+    public UIStateTracker clone() {
+        try {
+            UIStateTracker copy = (UIStateTracker) super.clone();
+            if (lastSnapshot != null) {
+                copy.lastSnapshot = new ArrayList<>(lastSnapshot);
+            }
+            return copy;
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError(e);
+        }
+    }
+}
+
+// vim: set sw=4 ts=8 expandtab:


### PR DESCRIPTION
## Summary

Adds state tracking to all 5 dialog window types so that clicking Apply, OK, or Restore Defaults is a no-op when the UI state hasn't changed since the last apply.

### Approach
- **State snapshot** (SmoothingWindow, FilterWindow, FATSChartFrame, PreferencesEditor): `captureState()` returns `Object[]` of current UI values, compared via `Arrays.equals()` to `lastAppliedState`
- **Dirty flag** (RangeSelectorWindow): Tree-based selection uses a simpler dirty flag

### Files changed
- `ECUxPlotWindow.java` — dirty flag infrastructure
- `SmoothingWindow.java` — state snapshot for smoothing params
- `FilterWindow.java` — state snapshot for filter params
- `RangeSelectorWindow.java` — dirty flag on tree clicks
- `FATSChartFrame.java` — state snapshot with combo box handling
- `PreferencesEditor.java` — generic field tracking with `trackField()`
- `FATSEditor.java` — override `captureState()` for custom fields
- `PIDEditor.java` — register 9 custom fields

## Testing
- `make compile` — builds successfully
- `make test` — all 12 tests pass

Closes #121